### PR TITLE
Correct options.family parameter to match node:net specification

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -71,9 +71,11 @@ function Connection(r, options, resolve, reject) {
     this.connection = options.connection;
   }
   else {
-    var family = 'IPv4';
+    // per node:net.connect specification
+    //    options.family: Version of IP stack. Must be 4, 6, or 0. The value 0 indicates that both IPv4 and IPv6 addresses are allowed. Default: 0.
+    var family = 4; // IPv4 
     if (net.isIPv6(self.host)) {
-      family = 'IPv6';
+      family = 6; // IPv6
     }
 
     var connectionArgs = {


### PR DESCRIPTION
Per node documentation, family parameter should be numeric 0 (any), 4 (ipv4), or 6 (ipv6)

warning appeared in node 18

https://nodejs.org/docs/latest-v18.x/api/net.html#socketconnectoptions-connectlistener